### PR TITLE
Add Swift questions to INTERVIEW.md

### DIFF
--- a/INTERVIEWS.md
+++ b/INTERVIEWS.md
@@ -162,10 +162,15 @@ For technical evaluations, you can:
 1. What is a protocol? When would you use it?
 1. What is autolayout? What does it mean when a constraint is *broken*? Can you help me set up the constraints in the following view?
 1. Have you ever worked with push notifications? Can you explain me what are the steps to receive push notifications?
-1. **Final exercise:** Give the candidate a computer and ask him/her to solve one of the issues from one of our [Swift open source projects](https://inaka.github.io/). Regarding difficulty, try to choose the right issue for the candidate, considering his/her techincal knowledge demonstrated in the previous questions. Ask him/her to follow the Inaka's git workflow (open a new branch, commit there, open a pull request and assign you as reviewer). You will be evaluating:
-  - Some of his/her git abilities (clone, branch, pull request)
-  - His/her skills facing a random problem.
-  - His work attitude overall.
+1. **Final exercise:** 
+  - We aim to evaluate:
+    - Some of his/her git abilities (clone, branch, pull request)
+    - His/her skills facing a random problem.
+    - His work attitude overall.
+  - For this, there are several options, among which these two are suggested:
+    - Ask candidates whether their would like to solve an issue of some of our [Swift open source projects](https://inaka.github.io/). It's important to make it clear that this is **optional**. If so, suggest them to do it following the Inaka's git workflow. They can solve this after the interview, like a homework.
+    - Otherwise, give them an exercise that they could solve in-place, during the interview.
+  - Always have in mind the level of difficulty of the issue or exercise you choose, based on how they answered the technical questions.
   
 ####Experience Questions
 1. What dependency managers do you know? Which one do you prefer, and why?


### PR DESCRIPTION
Added Swift questions, separated in two parts:
- **Technical:** For evaluating candidates
- **Experience:** For knowing about their experiences

I used [this google doc](https://docs.google.com/document/d/1o8ySfMF3oVLHfrDgkEqrQZy6Li9Q5iIK7heTuOcGJVs/edit) as reference.

Regarding my idea about Playgrounds, I think that we rather replace that with the final exercise I added to the Technical part. Reason: A playground would require updates and maintenance as Swift is evolving. Also, the exercise I propose is closer to a real case, regarding our way of working.
